### PR TITLE
membot: fix header file inclusion in graphnode header file

### DIFF
--- a/src/graphnode.h
+++ b/src/graphnode.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <string>
+#include <memory>
 #include "chatbot.h"
 
 


### PR DESCRIPTION
Add <memory> header file in graphnode header file to get definitions for smart pointers